### PR TITLE
add all endpoint

### DIFF
--- a/app/cache-freshener.sh
+++ b/app/cache-freshener.sh
@@ -22,7 +22,7 @@ curl -s ${LINKED_CONTAINER_NAME}:${PORT} > /json/index.html
 echo "Wrote base HTML file"
 
 # Add the service-list endpoint to the list of things to update
-ENDPOINTS="${ENDPOINTS} service-list"
+ENDPOINTS="${ENDPOINTS} service-list all"
 
 # Loop forever, sleeping for our frequency
 while true


### PR DESCRIPTION
Looks like it was removed in the previous commit. Re-add the secret /all endpoint for all ips